### PR TITLE
Remove dependency to 'ninja-servlet-1.4' because 'ninja-servlet-${ninja-...

### DIFF
--- a/ninja-appengine-demo/pom.xml
+++ b/ninja-appengine-demo/pom.xml
@@ -127,12 +127,6 @@
 
         <dependency>
             <groupId>org.ninjaframework</groupId>
-            <artifactId>ninja-servlet</artifactId>
-            <version>1.4</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.ninjaframework</groupId>
             <artifactId>ninja-core-test</artifactId>
             <version>${ninja.version}</version>
             <scope>test</scope>


### PR DESCRIPTION
...version}' is a transitive dependency of 'ninja-appengine-module'
