### PR TITLE
Update pom.xml

### DIFF
--- a/ninja-appengine-integration-test-blog/pom.xml
+++ b/ninja-appengine-integration-test-blog/pom.xml
@@ -115,8 +115,7 @@
             </plugin>
 
             <plugin>
-                <!-- It is not really recommended to use mvn appengine:devserver, 
-                    instead use jetty:run -->
+                <!-- Use App Engine's own Devserver when running Ninja, jetty:run may not work -->
                 <groupId>com.google.appengine</groupId>
                 <artifactId>appengine-maven-plugin</artifactId>
                 <version>${appengine.version}</version>


### PR DESCRIPTION
Sounds legit... :D Can you file a bug so we can fix it? You can also
remove the line and create a PR. Would be great...

Thanks,

Raphael


On Mon, May 25, 2015 at 11:33 PM, Balázs Daka <balazs@daka.info> wrote:
> Hi Raphael
>
> thanks for your reply. I think I was slightly disturbed by the following
> comment in the appengine plugin section of the pom.xml of
> ninja-appengine-integration-test-blog: "<!-- It is not really recommended to
> use mvn appengine:devserver, instead use jetty:run -->
>
> Cheers
> Balázs
>
>
> 2015. május 25., hétfő 23:25:57 UTC+2 időpontban Raphael Bauer a következőt
> írta:
>>
>> Hey Balázs,
>>
>>
>> Make sure you follow the documentation at:
>> https://github.com/ninjaframework/ninja-appengine.
>>
>> Most importantly you can use App Engine's own Devserver when running
>> Ninja. (jetty:run may not work - which is somewhat expected).