### PR TITLE
Configure Maven Fork Test parameters

### DIFF
--- a/ninja-appengine-blog-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/ninja-appengine-blog-archetype/src/main/resources/archetype-resources/pom.xml
@@ -155,7 +155,7 @@
                 <version>2.15</version>
                 <configuration>
                     <reuseForks>false</reuseForks>
-                    <forkCount>1</forkCount>
+                    <forkCount>1.5C</forkCount>
                 </configuration>
             </plugin>
 

--- a/ninja-appengine-integration-test-blog/pom.xml
+++ b/ninja-appengine-integration-test-blog/pom.xml
@@ -149,7 +149,7 @@
                 <version>2.15</version>
                 <configuration>
                     <reuseForks>false</reuseForks>
-                    <forkCount>1</forkCount>
+                    <forkCount>1.5C</forkCount>
                 </configuration>
             </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
                     <version>2.14.1</version>
                     <configuration>
                         <reuseForks>false</reuseForks>
-                        <forkCount>1</forkCount>
+                        <forkCount>1.5C</forkCount>
                     </configuration>
                 </plugin>
             </plugins>


### PR DESCRIPTION

Maven will run all tests in a single forked VM by default. This can be problematic if there are a lot of tests or some very memory-hungry ones. We can fork more test VM by setting `<fork>1.5C</fork>`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
